### PR TITLE
Add 'SOAPAction' header to the request

### DIFF
--- a/lib/PromoStandards.ts
+++ b/lib/PromoStandards.ts
@@ -136,7 +136,10 @@ export namespace PromoStandards {
 
         axios
           .post(endpoint.url, requestXML, {
-            headers: { "Content-Type": "text/xml" }
+            headers: {
+              "Content-Type": "text/xml",
+              "SOAPAction": method
+            }
           })
           .then((result: any) => {
             this.format === "json"

--- a/test/PromoStandards.test.ts
+++ b/test/PromoStandards.test.ts
@@ -227,7 +227,7 @@ describe("Invoice", () => {
       expect(supplierClient.invoice.getInvoices).toBeDefined();
     });
     it("should return a promise, by default", () => {
-      return expect(supplierClient.invoice.getInvoices()).toBeInstanceOf(
+      return expect(supplierClient.invoice.getInvoices({})).toBeInstanceOf(
         Promise
       );
     });
@@ -402,7 +402,7 @@ describe("ProductData", () => {
     });
     it("should return a promise, by default", () => {
       return expect(
-        supplierClient.productData.getProductCloseOut()
+        supplierClient.productData.getProductCloseOut({})
       ).toBeInstanceOf(Promise);
     });
   });
@@ -446,7 +446,7 @@ describe("ProductPricingAndConfiguration", () => {
     });
     it("should return a promise, by default", () => {
       return expect(
-        supplierClient.productPricingAndConfiguration.getAvailableLocations()
+        supplierClient.productPricingAndConfiguration.getAvailableLocations({})
       ).toBeInstanceOf(Promise);
     });
   });
@@ -460,7 +460,7 @@ describe("ProductPricingAndConfiguration", () => {
     });
     it("should return a promise, by default", () => {
       return expect(
-        supplierClient.productPricingAndConfiguration.getDecorationColors()
+        supplierClient.productPricingAndConfiguration.getDecorationColors({})
       ).toBeInstanceOf(Promise);
     });
   });
@@ -473,7 +473,7 @@ describe("ProductPricingAndConfiguration", () => {
     });
     it("should return a promise, by default", () => {
       return expect(
-        supplierClient.productPricingAndConfiguration.getFobPoints()
+        supplierClient.productPricingAndConfiguration.getFobPoints({})
       ).toBeInstanceOf(Promise);
     });
   });
@@ -486,7 +486,7 @@ describe("ProductPricingAndConfiguration", () => {
     });
     it("should return a promise, by default", () => {
       return expect(
-        supplierClient.productPricingAndConfiguration.getAvailableCharges()
+        supplierClient.productPricingAndConfiguration.getAvailableCharges({})
       ).toBeInstanceOf(Promise);
     });
   });
@@ -499,7 +499,7 @@ describe("ProductPricingAndConfiguration", () => {
     });
     it("should return a promise, by default", () => {
       return expect(
-        supplierClient.productPricingAndConfiguration.getConfigurationAndPricing()
+        supplierClient.productPricingAndConfiguration.getConfigurationAndPricing({})
       ).toBeInstanceOf(Promise);
     });
   });

--- a/test/PromoStandards.test.ts
+++ b/test/PromoStandards.test.ts
@@ -70,6 +70,15 @@ describe("PromoStandardsClient", () => {
   describe("promoStandardsAPIRequest()", () => {
     nock("https://test.dev")
       .persist()
+      .defaultReplyHeaders({ 
+        "access-control-allow-origin": "*",
+        "access-control-allow-headers": "SOAPAction"
+      })
+      .options("/ProductData")
+      .reply(200);
+
+    nock("https://test.dev")
+      .persist()
       .defaultReplyHeaders({ "access-control-allow-origin": "*" })
       .post("/ProductData")
       .reply(


### PR DESCRIPTION
This header specifies the method to be used and is a required header. The requests were throwing `500` error without this. Apparently, this is not an issue for HitPromo end-points.