### PR TITLE
Send product id only if available through getProductsSellable

### DIFF
--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -256,7 +256,8 @@ export const getProductSellable: () => string = pug.compile(
       shar:id #{id}
       if password
         shar:password #{password}
-      shar:productId #{productId}
+      if productId
+        shar:productId #{productId}
       if partId
         shar:partId #{partId}
       shar:isSellable #{isSellable}`


### PR DESCRIPTION
An empty tag causes issues for some suppliers if the product id is missing. This commit ensures that the tag is added only if the id is present.